### PR TITLE
Removal of parallel LST path generation.

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,24 +2,11 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="be320640-be59-4f3f-a247-e4c7e85fe7e4" name="Default" comment="">
-      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/ard/constants.py" />
-      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/submit.slurm" />
-      <change type="DELETED" beforePath="$PROJECT_DIR$/example_scripts/submit.slurm" afterPath="" />
-      <change type="MOVED" beforePath="$PROJECT_DIR$/ard/tssearch.py" afterPath="$PROJECT_DIR$/tssearch.py" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/.idea/dictionaries/User1.xml" afterPath="$PROJECT_DIR$/.idea/dictionaries/User1.xml" />
       <change type="MODIFICATION" beforePath="$PROJECT_DIR$/.idea/workspace.xml" afterPath="$PROJECT_DIR$/.idea/workspace.xml" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/README.md" afterPath="$PROJECT_DIR$/README.md" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/ard.py" afterPath="$PROJECT_DIR$/ard.py" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/ard/gen3D.py" afterPath="$PROJECT_DIR$/ard/gen3D.py" />
       <change type="MODIFICATION" beforePath="$PROJECT_DIR$/ard/interpolation.py" afterPath="$PROJECT_DIR$/ard/interpolation.py" />
       <change type="MODIFICATION" beforePath="$PROJECT_DIR$/ard/main.py" afterPath="$PROJECT_DIR$/ard/main.py" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/ard/node.py" afterPath="$PROJECT_DIR$/ard/node.py" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/ard/pgen.py" afterPath="$PROJECT_DIR$/ard/pgen.py" />
       <change type="MODIFICATION" beforePath="$PROJECT_DIR$/ard/quantum.py" afterPath="$PROJECT_DIR$/ard/quantum.py" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/ard/sm.py" afterPath="$PROJECT_DIR$/ard/sm.py" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/ard/util.py" afterPath="$PROJECT_DIR$/ard/util.py" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/input.txt" afterPath="$PROJECT_DIR$/input.txt" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/requirements.txt" afterPath="$PROJECT_DIR$/requirements.txt" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/tssearch.py" afterPath="$PROJECT_DIR$/tssearch.py" />
     </list>
     <ignored path="AutomaticReactionDiscovery.iws" />
     <ignored path=".idea/" />
@@ -42,8 +29,28 @@
       <file leaf-file-name="main.py" pinned="false" current-in-tab="true">
         <entry file="file://$PROJECT_DIR$/ard/main.py">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="-525">
-              <caret line="24" column="30" selection-start-line="24" selection-start-column="30" selection-end-line="24" selection-end-column="30" />
+            <state relative-caret-position="357">
+              <caret line="127" column="23" selection-start-line="127" selection-start-column="23" selection-end-line="127" selection-end-column="23" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="tssearch.py" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/tssearch.py">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="357">
+              <caret line="117" column="39" selection-start-line="117" selection-start-column="39" selection-end-line="117" selection-end-column="39" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="util.py" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/ard/util.py">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="-2079">
+              <caret line="21" column="42" selection-start-line="21" selection-start-column="42" selection-end-line="21" selection-end-column="42" />
               <folding />
             </state>
           </provider>
@@ -111,25 +118,25 @@
         <option value="$PROJECT_DIR$/ard/node.py" />
         <option value="$PROJECT_DIR$/ard/tssearch.py" />
         <option value="$PROJECT_DIR$/example_scripts/submit.slurm" />
-        <option value="$PROJECT_DIR$/ard/interpolation.py" />
         <option value="$PROJECT_DIR$/requirements.txt" />
         <option value="$PROJECT_DIR$/test.py" />
-        <option value="$PROJECT_DIR$/tssearch.py" />
         <option value="$PROJECT_DIR$/README.md" />
         <option value="$PROJECT_DIR$/ard/gen3D.py" />
         <option value="$PROJECT_DIR$/input.txt" />
         <option value="$PROJECT_DIR$/submit.slurm" />
-        <option value="$PROJECT_DIR$/ard/quantum.py" />
         <option value="$PROJECT_DIR$/ard/util.py" />
         <option value="$PROJECT_DIR$/ard/main.py" />
+        <option value="$PROJECT_DIR$/ard/quantum.py" />
+        <option value="$PROJECT_DIR$/ard/interpolation.py" />
+        <option value="$PROJECT_DIR$/tssearch.py" />
       </list>
     </option>
   </component>
   <component name="ProjectFrameBounds">
-    <option name="x" value="-9" />
-    <option name="y" value="-9" />
-    <option name="width" value="1938" />
-    <option name="height" value="1048" />
+    <option name="x" value="1911" />
+    <option name="y" value="21" />
+    <option name="width" value="1698" />
+    <option name="height" value="1018" />
   </component>
   <component name="ProjectInspectionProfilesVisibleTreeState">
     <entry key="Project Default">
@@ -175,8 +182,6 @@
       <foldersAlwaysOnTop value="true" />
     </navigator>
     <panes>
-      <pane id="Scratches" />
-      <pane id="Scope" />
       <pane id="ProjectPane">
         <subPane>
           <PATH>
@@ -211,6 +216,8 @@
           </PATH>
         </subPane>
       </pane>
+      <pane id="Scratches" />
+      <pane id="Scope" />
     </panes>
   </component>
   <component name="PropertiesComponent">
@@ -481,10 +488,10 @@
     <servers />
   </component>
   <component name="ToolWindowManager">
-    <frame x="-9" y="-9" width="1938" height="1048" extended-state="6" />
+    <frame x="1911" y="21" width="1698" height="1018" extended-state="6" />
     <editor active="true" />
     <layout>
-      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.20729166" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
+      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.23690476" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
       <window_info id="TODO" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="6" side_tool="false" content_ui="tabs" />
       <window_info id="Event Log" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32821077" sideWeight="0.5" order="7" side_tool="true" content_ui="tabs" />
       <window_info id="Version Control" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32918552" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
@@ -664,24 +671,10 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/ard/sm.py">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-1617">
-          <caret line="463" column="50" selection-start-line="463" selection-start-column="50" selection-end-line="463" selection-end-column="50" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/ard/constants.py">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="722">
           <caret line="37" column="34" selection-start-line="37" selection-start-column="34" selection-end-line="37" selection-end-column="34" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/ard/pgen.py">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="252">
-          <caret line="12" column="47" selection-start-line="12" selection-start-column="47" selection-end-line="12" selection-end-column="47" />
         </state>
       </provider>
     </entry>
@@ -709,38 +702,10 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/tssearch.py">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="357">
-          <caret line="127" column="32" selection-start-line="127" selection-start-column="32" selection-end-line="127" selection-end-column="32" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/ard/interpolation.py">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-3381">
-          <caret line="19" column="1" selection-start-line="19" selection-start-column="1" selection-end-line="19" selection-end-column="1" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/submit.slurm">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="378">
           <caret line="18" column="0" selection-start-line="18" selection-start-column="0" selection-end-line="18" selection-end-column="0" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/ard/util.py">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="441">
-          <caret line="21" column="42" selection-start-line="21" selection-start-column="42" selection-end-line="21" selection-end-column="42" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/ard/quantum.py">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="1184">
-          <caret line="463" column="11" selection-start-line="463" selection-start-column="11" selection-end-line="463" selection-end-column="11" />
         </state>
       </provider>
     </entry>
@@ -755,17 +720,18 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="84">
           <caret line="4" column="5" selection-start-line="4" selection-start-column="5" selection-end-line="4" selection-end-column="5" />
+          <folding />
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/README.md">
+      <provider editor-type-id="MarkdownFxPreviewEditor">
+        <state />
+      </provider>
       <provider editor-type-id="text-editor">
         <state relative-caret-position="252">
           <caret line="12" column="0" selection-start-line="12" selection-start-column="0" selection-end-line="12" selection-end-column="0" />
         </state>
-      </provider>
-      <provider editor-type-id="MarkdownFxPreviewEditor">
-        <state />
       </provider>
       <provider selected="true" editor-type-id="split-provider[text-editor;MarkdownPreviewEditor]">
         <state split_layout="FIRST">
@@ -783,6 +749,14 @@
         </state>
       </provider>
     </entry>
+    <entry file="file://$PROJECT_DIR$/ard/pgen.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="-1848">
+          <caret line="12" column="47" selection-start-line="12" selection-start-column="47" selection-end-line="12" selection-end-column="47" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
     <entry file="file://$PROJECT_DIR$/input.txt">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="315">
@@ -791,10 +765,50 @@
         </state>
       </provider>
     </entry>
+    <entry file="file://$PROJECT_DIR$/ard/util.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="-2079">
+          <caret line="21" column="42" selection-start-line="21" selection-start-column="42" selection-end-line="21" selection-end-column="42" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/ard/interpolation.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="386">
+          <caret line="165" column="34" selection-start-line="165" selection-start-column="34" selection-end-line="165" selection-end-column="34" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/ard/quantum.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="546">
+          <caret line="546" column="56" selection-start-line="546" selection-start-column="56" selection-end-line="546" selection-end-column="56" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/ard/sm.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="5901">
+          <caret line="463" column="50" selection-start-line="463" selection-start-column="50" selection-end-line="463" selection-end-column="50" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/tssearch.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="357">
+          <caret line="117" column="39" selection-start-line="117" selection-start-column="39" selection-end-line="117" selection-end-column="39" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
     <entry file="file://$PROJECT_DIR$/ard/main.py">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-525">
-          <caret line="24" column="30" selection-start-line="24" selection-start-column="30" selection-end-line="24" selection-end-column="30" />
+        <state relative-caret-position="357">
+          <caret line="127" column="23" selection-start-line="127" selection-start-column="23" selection-end-line="127" selection-end-column="23" />
           <folding />
         </state>
       </provider>

--- a/ard/interpolation.py
+++ b/ard/interpolation.py
@@ -39,9 +39,6 @@ so that these can be serialized for map functions of parallelization packages.
 
 from __future__ import division
 
-import copy_reg
-import multiprocessing
-import types
 import warnings
 
 import numpy as np
@@ -49,33 +46,6 @@ from scipy import optimize
 
 import util
 from node import Node
-
-###############################################################################
-
-def _pickle_method(method):
-    """
-    Pickles method.
-    """
-    func_name = method.im_func.__name__
-    obj = method.im_self
-    cls = method.im_class
-    return _unpickle_method, (func_name, obj, cls)
-
-def _unpickle_method(func_name, obj, cls):
-    """
-    Unpickles method.
-    """
-    for cls in cls.mro():
-        try:
-            func = cls.__dict__[func_name]
-        except KeyError:
-            pass
-        else:
-            break
-    return func.__get__(obj, cls)
-
-# Add functionality for pickling bound methods
-copy_reg.pickle(types.MethodType, _pickle_method, _unpickle_method)
 
 ###############################################################################
 
@@ -191,11 +161,7 @@ class LST(CartesianInterp):
         inc = 1.0 / (nnodes - 1)
 
         # Compute LST path and add start and end node to path
-        if self.nproc > 1:
-            pool = multiprocessing.Pool(self.nproc)
-            path = list(pool.map(self.getLSTnode, np.linspace(inc, 1.0 - inc, nnodes - 2)))
-        else:
-            path = [self.getLSTnode(f) for f in np.linspace(inc, 1.0 - inc, nnodes - 2)]
+        path = [self.getLSTnode(f) for f in np.linspace(inc, 1.0 - inc, nnodes - 2)]
         path.insert(0, self.node_start)
         path.append(self.node_end)
 

--- a/ard/main.py
+++ b/ard/main.py
@@ -156,7 +156,7 @@ class ARD(object):
                 kwargs['logname'] = 'rxn' + rxn_num
 
                 product = mol.toNode()
-                self.logger.info('Reaction {}:\n{}\n{}\n'.format(rxn, mol.write().strip(), product))
+                self.logger.info('Reaction {}:\n{}\n{}\n'.format(rxn, mol.write('can').strip(), product))
 
                 self.makeInputFile(product, **kwargs)
                 job_script = makeBatchSubmissionScript(rxn_name, example_script_path, output_dir)

--- a/ard/quantum.py
+++ b/ard/quantum.py
@@ -431,7 +431,7 @@ class QChem(Quantum):
         corresponding energies in Hartrees.
         """
         for line in self.output:
-            if 'Reaction path following' in line:
+            if 'starting direction =' in line:
                 break
         else:
             raise QuantumError('Q-Chem output does not contain IRC calculation')
@@ -543,7 +543,7 @@ class QChem(Quantum):
 
         # Run job
         self.logfile = os.path.join(output_dir, name + '.log')
-        self.submitProcessAndCheck('qchem', '-np', nproc, self.input_file, self.logfile)
+        self.submitProcessAndCheck('qchem', '-np', 1, '-nt', nproc, self.input_file, self.logfile)
         os.remove(os.path.join(output_dir, 'pathtable'))
 
         # Read output

--- a/tssearch.py
+++ b/tssearch.py
@@ -153,6 +153,7 @@ class TSSearch(object):
         )
 
     @ard.util.logStartAndFinish
+    @ard.util.timeFn
     def preoptimizeProduct(self):
         """
         Optimize the product geometry.
@@ -185,6 +186,7 @@ class TSSearch(object):
         drawPath(self.fsm, filepath)
 
     @ard.util.logStartAndFinish
+    @ard.util.timeFn
     def executeExactTSSearch(self):
         """
         Run the exact transition state search and update `self.ts`.
@@ -207,6 +209,7 @@ class TSSearch(object):
         self.ngrad += ngrad
 
     @ard.util.logStartAndFinish
+    @ard.util.timeFn
     def executeIRC(self):
         """
         Run an IRC calculation using the exact TS geometry and save the path to
@@ -284,8 +287,10 @@ def drawPath(nodepath, filepath):
     reac_energy = nodepath[0].energy
     energies = [(node.energy - reac_energy) * 627.5095 for node in nodepath]
 
+    plt.figure()
     line = plt.plot(energies)
     plt.setp(line, c='b', ls='-', lw=2.0, marker='.', mec='k', mew=1.0, mfc='w', ms=17.0)
+    plt.xlabel('Node')
     plt.ylabel('Energy (kcal/mol)')
     plt.grid(True)
     plt.savefig(filepath)


### PR DESCRIPTION
The generation of the LST path in parallel resulted in severe overloading
of compute nodes, likely because bound methods were being parallelized in
a non-standard way. This functionality has been removed, which will
result in slightly slower code, but should not matter much since the main
computational expense are the quantum calculations.
